### PR TITLE
Add Timing chart to property view

### DIFF
--- a/observability-tools/src/datatypes.ts
+++ b/observability-tools/src/datatypes.ts
@@ -12,7 +12,8 @@ export const schemaTestCaseLine = z.object({
   how_generated: z.string().optional(),
   features: z.record(z.any()),
   coverage: z.union([z.record(z.array(z.number())), z.literal("no_coverage_info"), z.null()]),
-  metadata: z.any()
+  metadata: z.any(),
+  timing: z.record(z.number()),
 });
 
 export const schemaInfoLine = z.object({

--- a/observability-tools/src/datatypes.ts
+++ b/observability-tools/src/datatypes.ts
@@ -13,7 +13,7 @@ export const schemaTestCaseLine = z.object({
   features: z.record(z.any()),
   coverage: z.union([z.record(z.array(z.number())), z.literal("no_coverage_info"), z.null()]),
   metadata: z.any(),
-  timing: z.record(z.number()),
+  timing: z.record(z.number()).optional(),
 });
 
 export const schemaInfoLine = z.object({

--- a/webview-ui/src/panes/Charts.tsx
+++ b/webview-ui/src/panes/Charts.tsx
@@ -3,6 +3,7 @@ import { OrdinalChart } from "../visualization/OrdinalChart";
 import { NominalChart } from "../visualization/NominalChart";
 import Card from "../ui/Card";
 import { UniqueTimeChart } from "../visualization/UniqueTimeChart";
+import { TimingChart } from "../visualization/TimingChart";
 
 type ChartsProps = {
   dataset: SampleInfo[];
@@ -11,46 +12,48 @@ type ChartsProps = {
     nominal: string[];
   };
   setFilteredView: (exampleFilter: ExampleFilter) => void;
-}
+};
 
 export const Charts = (props: ChartsProps) => {
   const { dataset: rawDataset, features } = props;
 
-  const dataset = rawDataset.filter((x) => x.outcome === "passed" || x.outcome === "failed")
+  const dataset = rawDataset.filter((x) => x.outcome === "passed" || x.outcome === "failed");
 
   const coverageChart = null; // CoverageChart({ dataset });
 
-  return <div className="w-full grid grid-cols-1">
-    {coverageChart &&
-      <Card>
-        {coverageChart}
-      </Card>}
-    {[...features.nominal.map((x) =>
-      <Card key={`bucket-${x}`}>
-        <NominalChart
-          feature={x}
-          dataset={dataset}
-          viewValue={(value) => props.setFilteredView({ nominal: x, value })} />
-      </Card>
-    ),
-    ...features.ordinal.flatMap((x) =>
-      [
-        <Card key={`feature-${x}`}>
-          <OrdinalChart
-            feature={x}
-            dataset={dataset}
-            viewValue={(value) => props.setFilteredView({ ordinal: x, value })} />
-        </Card>,
-      ]),
-    ]}
-    {/* <Card className="text-sm">
+  return (
+    <div className="grid w-full grid-cols-1">
+      {coverageChart && <Card>{coverageChart}</Card>}
+      {[
+        ...features.nominal.map((x) => (
+          <Card key={`bucket-${x}`}>
+            <NominalChart
+              feature={x}
+              dataset={dataset}
+              viewValue={(value) => props.setFilteredView({ nominal: x, value })}
+            />
+          </Card>
+        )),
+        ...features.ordinal.flatMap((x) => [
+          <Card key={`feature-${x}`}>
+            <OrdinalChart
+              feature={x}
+              dataset={dataset}
+              viewValue={(value) => props.setFilteredView({ ordinal: x, value })}
+            />
+          </Card>,
+        ]),
+      ]}
+      {/* <Card className="text-sm">
       <strong>NOTE:</strong> You can add your own charts by registering "features" for your test
       inputs. Consult your PBT framework's documentation to learn more.
     </Card> */}
-    <Card>
-      <UniqueTimeChart
-        dataset={dataset}
-      />
-    </Card>
-  </div >;
-}
+      <Card>
+        <UniqueTimeChart dataset={dataset} />
+      </Card>
+      <Card>
+        <TimingChart dataset={dataset} />
+      </Card>
+    </div>
+  );
+};

--- a/webview-ui/src/panes/Charts.tsx
+++ b/webview-ui/src/panes/Charts.tsx
@@ -51,17 +51,15 @@ export const Charts = (props: ChartsProps) => {
       <Card>
         <UniqueTimeChart dataset={dataset} />
       </Card>
-      <Card>
-        <TimingChart
-          dataset={dataset}
-          viewValues={(examples) =>
-            props.setFilteredView({
-              subset: "Selected samples by time taken",
-              examples,
-            })
-          }
-        />
-      </Card>
+      <TimingChart
+        dataset={dataset}
+        viewValues={(examples) =>
+          props.setFilteredView({
+            subset: "Selected samples by time taken",
+            examples,
+          })
+        }
+      />
     </div>
   );
 };

--- a/webview-ui/src/panes/Charts.tsx
+++ b/webview-ui/src/panes/Charts.tsx
@@ -52,7 +52,15 @@ export const Charts = (props: ChartsProps) => {
         <UniqueTimeChart dataset={dataset} />
       </Card>
       <Card>
-        <TimingChart dataset={dataset} />
+        <TimingChart
+          dataset={dataset}
+          viewValues={(examples) =>
+            props.setFilteredView({
+              subset: "Selected samples by time taken",
+              examples,
+            })
+          }
+        />
       </Card>
     </div>
   );

--- a/webview-ui/src/visualization/TimingChart.tsx
+++ b/webview-ui/src/visualization/TimingChart.tsx
@@ -22,8 +22,8 @@ export const TimingChart = ({ dataset, viewValues }: TimingChartProps) => {
   }
 
   dataset.sort((a, b) => {
-    if ("timing" in a.dataLine) {
-      if ("timing" in b.dataLine) {
+    if ("timing" in a.dataLine && a.dataLine.timing) {
+      if ("timing" in b.dataLine && b.dataLine.timing) {
         return (
           Object.values(a.dataLine.timing).reduce((acc, v) => acc + v, 0) -
           Object.values(b.dataLine.timing).reduce((acc, v) => acc + v, 0)
@@ -41,7 +41,7 @@ export const TimingChart = ({ dataset, viewValues }: TimingChartProps) => {
   });
   const cumulativeData: { step: number; event: string; time: number }[] = dataset.flatMap(
     (x, step) =>
-      "timing" in x.dataLine
+      "timing" in x.dataLine && x.dataLine.timing
         ? Object.entries(x.dataLine.timing).map(([event, time]) => ({ step, event, time }))
         : []
   );

--- a/webview-ui/src/visualization/TimingChart.tsx
+++ b/webview-ui/src/visualization/TimingChart.tsx
@@ -1,0 +1,144 @@
+import { SampleInfo } from "../report";
+import { THEME_COLORS } from "../utilities/colors";
+import { VisualizationSpec } from "react-vega";
+import Distribution, { vegaConfig } from "./Distribution";
+import { useState } from "react";
+
+type TimingChartProps = {
+  dataset: SampleInfo[];
+};
+
+export const TimingChart = ({ dataset }: TimingChartProps) => {
+  const [cumulative, setCumulative] = useState(false);
+  const handleSetCumulative = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setCumulative(e.target.checked);
+  };
+
+  if (dataset.length === 0) {
+    return <div className="text-center">No samples</div>;
+  }
+
+  dataset.sort((a, b) => {
+    if ("timing" in a.dataLine) {
+      if ("timing" in b.dataLine) {
+        return (
+          Object.values(a.dataLine.timing).reduce((acc, v) => acc + v, 0) -
+          Object.values(b.dataLine.timing).reduce((acc, v) => acc + v, 0)
+        );
+      } else {
+        return 1;
+      }
+    } else {
+      if ("timing" in b.dataLine) {
+        return -1;
+      } else {
+        return 0;
+      }
+    }
+  });
+  const cumulativeData: { step: number; event: string; time: number }[] = dataset.flatMap(
+    (x, step) =>
+      "timing" in x.dataLine
+        ? Object.entries(x.dataLine.timing).map(([event, time]) => ({ step, event, time }))
+        : []
+  );
+
+  const cumulativeSpec: VisualizationSpec = {
+    $schema: "https://vega.github.io/schema/vega-lite/v5.json",
+    config: vegaConfig,
+    data: { name: "table", values: cumulativeData },
+    mark: { type: "area", tooltip: true },
+    width: "container",
+    height: 100,
+    params: [
+      {
+        name: "brush",
+        select: {
+          type: "interval",
+          on: "[pointerdown[event.shiftKey], pointerup] > pointermove",
+        },
+      },
+      {
+        name: "grid",
+        select: {
+          type: "interval",
+          on: "[pointerdown[!event.shiftKey], pointerup] > pointermove[!event.shiftKey]",
+        },
+        bind: "scales",
+      },
+    ],
+    transform: [
+      {
+        sort: [{ field: "step", order: "ascending" }],
+        window: [
+          {
+            op: "sum",
+            field: "time",
+            as: "cumulative_time",
+          },
+        ],
+      },
+    ],
+    encoding: {
+      x: { field: "step", type: "quantitative", axis: { title: null } },
+      y: cumulative
+        ? {
+            aggregate: "sum",
+            field: "cumulative_time",
+            title: "Cumulative time",
+          }
+        : {
+            aggregate: "sum",
+            field: "time",
+            title: "Time",
+          },
+      color: {
+        field: "event",
+        title: "Event",
+      },
+    },
+  };
+
+  // const totalTimeData = dataset.map((x) => ({
+  //   totalTime:
+  //     "timing" in x.dataLine ? Object.entries(x.dataLine.timing).reduce((a, [, b]) => a + b, 0) : 0,
+  // }));
+
+  // Samples binned by total time
+  // const binnedSpec: VisualizationSpec = {
+  //   $schema: "https://vega.github.io/schema/vega-lite/v5.json",
+  //   config: vegaConfig,
+  //   width: "container",
+  //   data: { name: "table", values: totalTimeData },
+  //   mark: { type: "bar", tooltip: true },
+  //   encoding: {
+  //     x: {
+  //       bin: {
+  //         maxbins: 20,
+  //       },
+  //       field: "totalTime",
+  //       type: "quantitative",
+  //     },
+  //     y: {
+  //       aggregate: "count",
+  //       scale: {
+  //         zero: true,
+  //       },
+  //     },
+  //   },
+  // };
+
+  return (
+    <>
+      <label className="flex items-center my-4 text-lg">
+        <input type="checkbox" className="w-6 h-6" onChange={handleSetCumulative} />
+        <span className="ml-2 leading-none">Cumulative</span>
+      </label>
+      <Distribution
+        title={<span className="font-bold">Timing Breakdown</span>}
+        spec={cumulativeSpec}
+        listeners={{}}
+      />
+    </>
+  );
+};

--- a/webview-ui/src/visualization/TimingChart.tsx
+++ b/webview-ui/src/visualization/TimingChart.tsx
@@ -3,6 +3,7 @@ import { VisualizationSpec, SignalListeners } from "react-vega";
 import Distribution, { vegaConfig } from "./Distribution";
 import { SampleInfo } from "../report";
 import { THEME_COLORS } from "../utilities/colors";
+import Card from "../ui/Card";
 
 type TimingChartProps = {
   dataset: SampleInfo[];
@@ -17,8 +18,11 @@ export const TimingChart = ({ dataset, viewValues }: TimingChartProps) => {
 
   const [brush, setBrush] = useState<[number, number] | null>(null);
 
-  if (dataset.length === 0) {
-    return <div className="text-center">No samples</div>;
+  if (
+    dataset.length === 0 ||
+    dataset.every((x) => !("timing" in x.dataLine && x.dataLine.timing))
+  ) {
+    return null;
   }
 
   dataset.sort((a, b) => {
@@ -113,7 +117,7 @@ export const TimingChart = ({ dataset, viewValues }: TimingChartProps) => {
   };
 
   return (
-    <>
+    <Card>
       <Distribution
         title={<span className="font-bold">Timing Breakdown</span>}
         spec={cumulativeSpec}
@@ -135,6 +139,6 @@ export const TimingChart = ({ dataset, viewValues }: TimingChartProps) => {
         title={brush == null ? "Use shift + drag to select a range of samples" : undefined}>
         View selected samples <i className="ml-1 codicon codicon-arrow-right" />
       </button>
-    </>
+    </Card>
   );
 };

--- a/webview-ui/src/visualization/TimingChart.tsx
+++ b/webview-ui/src/visualization/TimingChart.tsx
@@ -1,18 +1,21 @@
+import { useState } from "react";
+import { VisualizationSpec, SignalListeners } from "react-vega";
+import Distribution, { vegaConfig } from "./Distribution";
 import { SampleInfo } from "../report";
 import { THEME_COLORS } from "../utilities/colors";
-import { VisualizationSpec } from "react-vega";
-import Distribution, { vegaConfig } from "./Distribution";
-import { useState } from "react";
 
 type TimingChartProps = {
   dataset: SampleInfo[];
+  viewValues: (samples: SampleInfo[]) => void;
 };
 
-export const TimingChart = ({ dataset }: TimingChartProps) => {
+export const TimingChart = ({ dataset, viewValues }: TimingChartProps) => {
   const [cumulative, setCumulative] = useState(false);
   const handleSetCumulative = (e: React.ChangeEvent<HTMLInputElement>) => {
     setCumulative(e.target.checked);
   };
+
+  const [brush, setBrush] = useState<[number, number] | null>(null);
 
   if (dataset.length === 0) {
     return <div className="text-center">No samples</div>;
@@ -55,14 +58,18 @@ export const TimingChart = ({ dataset }: TimingChartProps) => {
         name: "brush",
         select: {
           type: "interval",
-          on: "[pointerdown[event.shiftKey], pointerup] > pointermove",
+          on: "[mousedown[event.shiftKey], mouseup] > mousemove!",
+          translate: "[mousedown[event.shiftKey], mouseup] > mousemove!",
+          zoom: "wheel![event.shiftKey]",
         },
       },
       {
-        name: "grid",
+        name: "pan_zoom",
         select: {
           type: "interval",
-          on: "[pointerdown[!event.shiftKey], pointerup] > pointermove[!event.shiftKey]",
+          on: "[mousedown[!event.shiftKey], mouseup] > mousemove",
+          translate: "[mousedown[!event.shiftKey], mouseup] > mousemove!",
+          zoom: "wheel![!event.shiftKey]",
         },
         bind: "scales",
       },
@@ -99,46 +106,35 @@ export const TimingChart = ({ dataset }: TimingChartProps) => {
     },
   };
 
-  // const totalTimeData = dataset.map((x) => ({
-  //   totalTime:
-  //     "timing" in x.dataLine ? Object.entries(x.dataLine.timing).reduce((a, [, b]) => a + b, 0) : 0,
-  // }));
-
-  // Samples binned by total time
-  // const binnedSpec: VisualizationSpec = {
-  //   $schema: "https://vega.github.io/schema/vega-lite/v5.json",
-  //   config: vegaConfig,
-  //   width: "container",
-  //   data: { name: "table", values: totalTimeData },
-  //   mark: { type: "bar", tooltip: true },
-  //   encoding: {
-  //     x: {
-  //       bin: {
-  //         maxbins: 20,
-  //       },
-  //       field: "totalTime",
-  //       type: "quantitative",
-  //     },
-  //     y: {
-  //       aggregate: "count",
-  //       scale: {
-  //         zero: true,
-  //       },
-  //     },
-  //   },
-  // };
+  const listeners: SignalListeners = {
+    brush: (name, value) => {
+      setBrush((value as { step?: [number, number] }).step ?? null);
+    },
+  };
 
   return (
     <>
-      <label className="flex items-center my-4 text-lg">
-        <input type="checkbox" className="w-6 h-6" onChange={handleSetCumulative} />
-        <span className="ml-2 leading-none">Cumulative</span>
-      </label>
       <Distribution
         title={<span className="font-bold">Timing Breakdown</span>}
         spec={cumulativeSpec}
-        listeners={{}}
+        listeners={listeners}
       />
+      <label className="flex items-center my-4 text-lg">
+        <input type="checkbox" className="w-4 h-4" onChange={handleSetCumulative} />
+        <span className="ml-2 leading-none">Cumulative</span>
+      </label>
+      <button
+        className={
+          "w-full py-1 text-center rounded-md " +
+          (brush == null
+            ? "cursor-not-allowed"
+            : "cursor-pointer hover:bg-primary hover:bg-opacity-25")
+        }
+        onClick={() => viewValues(dataset.slice(brush?.[0] ?? 0, brush?.[1] ?? dataset.length))}
+        disabled={brush == null}
+        title={brush == null ? "Use shift + drag to select a range of samples" : undefined}>
+        View selected samples <i className="ml-1 codicon codicon-arrow-right" />
+      </button>
     </>
   );
 };


### PR DESCRIPTION
Per-sample view, sorted by total time taken
![image](https://github.com/tyche-pbt/tyche-extension/assets/3701912/4e58101e-949e-42c8-819e-ecad2d023fae)

Cumulative time taken across all samples (still sorted by total time taken per-sample)
![image](https://github.com/tyche-pbt/tyche-extension/assets/3701912/81e8c0b4-8ddd-461c-bc59-827b4c1a61b2)

Zoom/Pan by dragging. Select a range by holding Shift  + dragging, then click "View selected samples" to get the example view.
![image](https://github.com/tyche-pbt/tyche-extension/assets/3701912/be248f82-6ad2-4bbc-aee7-12070cca8a31)
