### PR TITLE
Don't unnecessarily render seconds in exponential notation

### DIFF
--- a/webview-ui/src/panes/HighLevelStats.tsx
+++ b/webview-ui/src/panes/HighLevelStats.tsx
@@ -77,7 +77,7 @@ export const HighLevelStats = (props: HighLevelStatsProps) => {
           <div className="flex">
             <div className="flex-1 text-sm opacity-60">Spent</div>
           </div>
-          <span className="text-3xl">{totalTime.toPrecision(2)}</span> seconds testing.
+          <span className="text-3xl">{totalTime >= 10 ? Math.round(totalTime) : totalTime.toPrecision(2)}</span> seconds testing.
         </Card>
       }
       <Card className="col-span-2">


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/24d21d7a-345d-445e-9cee-1208cf56a125)
